### PR TITLE
Use an escape character for CR

### DIFF
--- a/h2c
+++ b/h2c
@@ -72,7 +72,7 @@ my $line = 1;
 while(<STDIN>) {
     my $l = $_;
     # discard CRs completely
-    $l =~ s///g;
+    $l =~ s/\r//g;
     if(!$state) {
         chomp $l;
         if($l =~ /([^ ]*) +(.*) +(HTTP\/.*)/) {


### PR DESCRIPTION
This prevents issues with git and IDE's that try to "fix" a CR character.